### PR TITLE
Correctly patch build file

### DIFF
--- a/recipe/build.patch
+++ b/recipe/build.patch
@@ -4,16 +4,15 @@ Date: Sun, 3 Nov 2019 21:05:24 +0100
 Subject: [PATCH] add build patch
 
 ---
- dvc/build.py | 1 +
- 1 file changed, 1 insertion(+)
- create mode 100644 dvc/build.py
+ dvc/utils/build.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/dvc/build.py b/dvc/build.py
-new file mode 100644
-index 00000000..84c77c84
---- /dev/null
-+++ b/dvc/build.py
-@@ -0,0 +1 @@
+diff --git a/dvc/utils/build.py b/dvc/utils/build.py
+index 7bf1d88..84c77c8 100644
+--- a/dvc/utils/build.py
++++ b/dvc/utils/build.py
+@@ -1 +1 @@
+-PKG = "pip"
 +PKG = "conda"
 -- 
 2.17.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - build.patch
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   skip: true  # [py<36]
   entry_points:


### PR DESCRIPTION
Closes https://github.com/conda-forge/dvc-feedstock/issues/136
Refer https://github.com/iterative/dvc/issues/4408

`dvc version` was showing up as `pip` due to the fault in patching

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
