### PR TITLE
Support standalone dvc installation via metapackages. 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @efiop @shcheklein @skshetry
+* @asford @efiop @shcheklein @skshetry

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@asford](https://github.com/asford/)
 * [@efiop](https://github.com/efiop/)
 * [@shcheklein](https://github.com/shcheklein/)
 * [@skshetry](https://github.com/skshetry/)

--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-_dvc-green.svg)](https://anaconda.org/conda-forge/_dvc) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/_dvc.svg)](https://anaconda.org/conda-forge/_dvc) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/_dvc.svg)](https://anaconda.org/conda-forge/_dvc) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/_dvc.svg)](https://anaconda.org/conda-forge/_dvc) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-_dvc--azure-green.svg)](https://anaconda.org/conda-forge/_dvc-azure) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/_dvc-azure.svg)](https://anaconda.org/conda-forge/_dvc-azure) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/_dvc-azure.svg)](https://anaconda.org/conda-forge/_dvc-azure) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/_dvc-azure.svg)](https://anaconda.org/conda-forge/_dvc-azure) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-_dvc--gdrive-green.svg)](https://anaconda.org/conda-forge/_dvc-gdrive) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/_dvc-gdrive.svg)](https://anaconda.org/conda-forge/_dvc-gdrive) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/_dvc-gdrive.svg)](https://anaconda.org/conda-forge/_dvc-gdrive) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/_dvc-gdrive.svg)](https://anaconda.org/conda-forge/_dvc-gdrive) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-_dvc--gs-green.svg)](https://anaconda.org/conda-forge/_dvc-gs) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/_dvc-gs.svg)](https://anaconda.org/conda-forge/_dvc-gs) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/_dvc-gs.svg)](https://anaconda.org/conda-forge/_dvc-gs) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/_dvc-gs.svg)](https://anaconda.org/conda-forge/_dvc-gs) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-_dvc--hdfs-green.svg)](https://anaconda.org/conda-forge/_dvc-hdfs) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/_dvc-hdfs.svg)](https://anaconda.org/conda-forge/_dvc-hdfs) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/_dvc-hdfs.svg)](https://anaconda.org/conda-forge/_dvc-hdfs) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/_dvc-hdfs.svg)](https://anaconda.org/conda-forge/_dvc-hdfs) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-_dvc--oss-green.svg)](https://anaconda.org/conda-forge/_dvc-oss) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/_dvc-oss.svg)](https://anaconda.org/conda-forge/_dvc-oss) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/_dvc-oss.svg)](https://anaconda.org/conda-forge/_dvc-oss) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/_dvc-oss.svg)](https://anaconda.org/conda-forge/_dvc-oss) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-_dvc--s3-green.svg)](https://anaconda.org/conda-forge/_dvc-s3) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/_dvc-s3.svg)](https://anaconda.org/conda-forge/_dvc-s3) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/_dvc-s3.svg)](https://anaconda.org/conda-forge/_dvc-s3) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/_dvc-s3.svg)](https://anaconda.org/conda-forge/_dvc-s3) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-_dvc--ssh-green.svg)](https://anaconda.org/conda-forge/_dvc-ssh) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/_dvc-ssh.svg)](https://anaconda.org/conda-forge/_dvc-ssh) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/_dvc-ssh.svg)](https://anaconda.org/conda-forge/_dvc-ssh) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/_dvc-ssh.svg)](https://anaconda.org/conda-forge/_dvc-ssh) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-dvc-green.svg)](https://anaconda.org/conda-forge/dvc) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dvc.svg)](https://anaconda.org/conda-forge/dvc) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dvc.svg)](https://anaconda.org/conda-forge/dvc) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dvc.svg)](https://anaconda.org/conda-forge/dvc) |
 
 Installing dvc
@@ -121,16 +129,16 @@ Installing `dvc` from the `conda-forge` channel can be achieved by adding `conda
 conda config --add channels conda-forge
 ```
 
-Once the `conda-forge` channel has been enabled, `dvc` can be installed with:
+Once the `conda-forge` channel has been enabled, `_dvc, _dvc-azure, _dvc-gdrive, _dvc-gs, _dvc-hdfs, _dvc-oss, _dvc-s3, _dvc-ssh, dvc` can be installed with:
 
 ```
-conda install dvc
+conda install _dvc _dvc-azure _dvc-gdrive _dvc-gs _dvc-hdfs _dvc-oss _dvc-s3 _dvc-ssh dvc
 ```
 
-It is possible to list all of the versions of `dvc` available on your platform with:
+It is possible to list all of the versions of `_dvc` available on your platform with:
 
 ```
-conda search dvc --channel conda-forge
+conda search _dvc --channel conda-forge
 ```
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,15 @@ source:
 build:
   number: 1
 
+# These tests are executed for the top-level `dvc` package
+test:
+  requires:
+    - git
+  imports:
+    - dvc
+  commands:
+    - dvc version
+
 # DVC includes requirements-only extras to enable support for different
 # remotes. Here we build a `dvc` conda package equivalent to the `dvc[all]` pip
 # package, with a `_dvc` base package containing dvc alone. This allows a
@@ -57,13 +66,6 @@ outputs:
         - {{ pin_subpackage("_dvc-oss", exact=True) }}
         - {{ pin_subpackage("_dvc-ssh", exact=True) }}
         - {{ pin_subpackage("_dvc-hdfs", exact=True) }}
-      test:
-        requires:
-          - git
-        imports:
-          - dvc
-        commands:
-          - dvc version
 
   - name: _dvc
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,6 +5,19 @@ package:
   name: {{ name|lower }}
   version: {{ version }}
 
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 905385b8cf616d9cd1e78530f0c8dc7f2064400efa72e6846fad689b5cfbf8fd
+  patches:
+    - build.patch
+
+# The "true" build is specified in the _dvc output below.
+# Of the build properties here and below:
+# noarch is not inherited and must be specified per output
+# number is propagated into the outputs below
+build:
+  number: 1
+
 # DVC includes requirements-only extras to enable support for different
 # remotes. Here we build a `dvc` conda package equivalent to the `dvc[all]` pip
 # package, with a `_dvc` base package containing dvc alone. This allows a
@@ -29,43 +42,29 @@ package:
 # Adding a new extra...
 #
 # Each extra needs to be added in two places:
-# 1. Add the extra with a pin_subpackage directive under `requirements.run`.
-# 2. Add the extra under `outputs` specifying the additional runtime requirements.
-
-source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 905385b8cf616d9cd1e78530f0c8dc7f2064400efa72e6846fad689b5cfbf8fd
-  patches:
-    - build.patch
-
-# The "true" build is specified in the _dvc output below.
-# Of the properties here:
-# noarch is not inherited and must be specified per output
-# number is propagated into the outputs below
-
-build:
-  number: 1
-
-requirements:
-  run:
-    - {{ pin_subpackage("_dvc", exact=True) }}
-    - {{ pin_subpackage("_dvc-gs", exact=True) }}
-    - {{ pin_subpackage("_dvc-gdrive", exact=True) }}
-    - {{ pin_subpackage("_dvc-s3", exact=True) }}
-    - {{ pin_subpackage("_dvc-azure", exact=True) }}
-    - {{ pin_subpackage("_dvc-oss", exact=True) }}
-    - {{ pin_subpackage("_dvc-ssh", exact=True) }}
-    - {{ pin_subpackage("_dvc-hdfs", exact=True) }}
-
-test:
-  requires:
-    - git
-  imports:
-    - dvc
-  commands:
-    - dvc version
-
+# 1. Under a new output specifying the additional runtime requirements
+# 2. Under outputs->dvc->requirements.run with a pin_subpackage directive, to
+#    include it in the `dvc` metapackage
 outputs:
+  - name: dvc
+    requirements:
+      run:
+        - {{ pin_subpackage("_dvc", exact=True) }}
+        - {{ pin_subpackage("_dvc-gs", exact=True) }}
+        - {{ pin_subpackage("_dvc-gdrive", exact=True) }}
+        - {{ pin_subpackage("_dvc-s3", exact=True) }}
+        - {{ pin_subpackage("_dvc-azure", exact=True) }}
+        - {{ pin_subpackage("_dvc-oss", exact=True) }}
+        - {{ pin_subpackage("_dvc-ssh", exact=True) }}
+        - {{ pin_subpackage("_dvc-hdfs", exact=True) }}
+      test:
+        requires:
+          - git
+        imports:
+          - dvc
+        commands:
+          - dvc version
+
   - name: _dvc
     build:
       entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,7 @@ source:
 # number is propagated into the outputs below
 build:
   number: 1
+  skip: true  # [py<36]
 
 # These tests are executed for the top-level `dvc` package
 test:
@@ -46,7 +47,7 @@ test:
 # We define extras through "private" subpackages and a single top-level `dvc`
 # metapackage. The metapackage at a given build version references the extras
 # subpackages at the same build version. `_dvc` includes the dvc package itself
-# and core dependencies. `_dvc-gs`, `_dv-s3`, et al contain no code, but
+# and core dependencies. `_dvc-gs`, `_dvc-s3`, et al contain no code, but
 # reference the `_dvc` base package and the requirements requirements for that extra.
 #
 # Adding a new extra...

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,7 +69,6 @@ test:
 outputs:
   - name: _dvc
     build:
-      noarch: python
       entry_points:
         - dvc = dvc.main:main
       script:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,10 +38,13 @@ source:
   patches:
     - build.patch
 
+# The "true" build is specified in the _dvc output below.
+# Of the properties here:
+# noarch is not inherited and must be specified per output
+# number is propagated into the outputs below
+
 build:
-  # noarch is not inherited below, and must be specified for every package
   noarch: python
-  # number is propagated into the outputs below
   number: 1
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,6 @@ source:
 # number is propagated into the outputs below
 
 build:
-  noarch: python
   number: 1
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -192,3 +192,5 @@ extra:
     - shcheklein
     - efiop
     - skshetry
+    # metapackage support
+    - asford

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,7 +71,7 @@ outputs:
       entry_points:
         - dvc = dvc.main:main
       script:
-        - ${PYTHON} -m pip install . --no-deps -vv
+        - python -m pip install . --no-deps -vv
 
     requirements:
       host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,6 +5,33 @@ package:
   name: {{ name|lower }}
   version: {{ version }}
 
+# DVC includes requirements-only extras to enable support for different
+# remotes. Here we build a `dvc` conda package equivalent to the `dvc[all]` pip
+# package, with a `_dvc` base package containing dvc alone. This allows a
+# happy-path of:
+#
+#   `conda install -c conda-forge dvc`
+#
+# supporting dvc and all remotes and a power-user path of:
+#
+#   `conda install -c conda-forge _dvc _dvc-s3`
+#
+# for dvc and specific remotes.
+#
+# Here's how it works...
+#
+# We define extras through "private" subpackages and a single top-level `dvc`
+# metapackage. The metapackage at a given build version references the extras
+# subpackages at the same build version. `_dvc` includes the dvc package itself
+# and core dependencies. `_dvc-gs`, `_dv-s3`, et al contain no code, but
+# reference the `_dvc` base package and the requirements requirements for that extra.
+#
+# Adding a new extra...
+#
+# Each extra needs to be added in two places:
+# 1. Add the extra with a pin_subpackage directive under `requirements.run`.
+# 2. Add the extra under `outputs` specifying the additional runtime requirements.
+
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 983aa453ae1d8f9319bfc9fbd1d37fd901e9538bfae00cec0b5156ca8c5a64d1
@@ -12,61 +39,21 @@ source:
     - build.patch
 
 build:
-  number: 0
-  script: {{ PYTHON }} -m pip install . -vv
-  skip: true  # [py<36]
-  entry_points:
-    - dvc = dvc.main:main
+  # noarch is not inherited below, and must be specified for every package
+  noarch: python
+  # number is propagated into the outputs below
+  number: 3
 
 requirements:
-  host:
-    - python
-    - pip
   run:
-    - python
-    - ply >=3.9
-    - colorama >=0.3.9
-    - configobj >=5.0.6
-    - gitpython >=2.1.8
-    - gitdb2 >=2.0.6
-    - setuptools >=34.0.0
-    - nanotime >=0.5.2
-    - pyasn1 >=0.4.1
-    - voluptuous >=0.11.7
-    - jsonpath-ng >=1.4.3
-    - requests >=2.22.0
-    - grandalf ==0.6
-    - distro >=1.3.0
-    - appdirs >=1.4.3
-    - ruamel.yaml >=0.16.1
-    - toml >=0.10.1
-    - funcy >=1.14
-    - pathspec >=0.6.0
-    - shortuuid >=0.5.0
-    - tqdm >=4.45.0,<5
-    - packaging >=19.0
-    - zc.lockfile >=1.2.1
-    - flufl.lock >=3.2,<4
-    - win_unicode_console >=0.5  # [win]
-    - pywin32 >=225  # [win]
-    - networkx >=2.1,<2.5
-    - pydot >=1.2.4
-    - dataclasses  # [py<37]
-    - flatten-dict >=0.3.0,<1
-    - tabulate >=0.8.7
-    - pygtrie ==2.3.2
-    - dpath >=1.4.2
-    - shtab >=1.3.2,<2
-    - rich >=3.0.5
-    - google-cloud-storage ==1.19.0
-    - pydrive2 >=1.6.2
-    - boto3 >=1.9.201
-    - azure-storage-blob >=12.0
-    - knack
-    - oss2 >=2.11.0
-    - paramiko >=2.7.0
-    - invoke >=1.3  # for paramiko, see https://github.com/iterative/dvc/issues/4589
-    - pyarrow >=0.17.1
+    - {{ pin_subpackage("_dvc", exact=True) }}
+    - {{ pin_subpackage("_dvc-gs", exact=True) }}
+    - {{ pin_subpackage("_dvc-gdrive", exact=True) }}
+    - {{ pin_subpackage("_dvc-s3", exact=True) }}
+    - {{ pin_subpackage("_dvc-azure", exact=True) }}
+    - {{ pin_subpackage("_dvc-oss", exact=True) }}
+    - {{ pin_subpackage("_dvc-ssh", exact=True) }}
+    - {{ pin_subpackage("_dvc-hdfs", exact=True) }}
 
 test:
   requires:
@@ -75,6 +62,116 @@ test:
     - dvc
   commands:
     - dvc version
+
+outputs:
+  - name: _dvc
+    build:
+      noarch: python
+      entry_points:
+        - dvc = dvc.main:main
+      script:
+        - ${PYTHON} -m pip install . --no-deps -vv
+
+    requirements:
+      host:
+        - python
+        - pip
+      run:
+        - python
+        - ply >=3.9
+        - colorama >=0.3.9
+        - configobj >=5.0.6
+        - gitpython >=2.1.8
+        - gitdb2 >=2.0.6
+        - setuptools >=34.0.0
+        - nanotime >=0.5.2
+        - pyasn1 >=0.4.1
+        - voluptuous >=0.11.7
+        - jsonpath-ng >=1.4.3
+        - requests >=2.22.0
+        - grandalf ==0.6
+        - distro >=1.3.0
+        - appdirs >=1.4.3
+        - ruamel.yaml >=0.16.1
+        - toml >=0.10.1
+        - funcy >=1.14
+        - pathspec >=0.6.0
+        - shortuuid >=0.5.0
+        - tqdm >=4.45.0,<5
+        - packaging >=19.0
+        - zc.lockfile >=1.2.1
+        - flufl.lock >=3.2,<4
+        - win_unicode_console >=0.5  # [win]
+        - pywin32 >=225  # [win]
+        - networkx >=2.1,<2.5
+        - pydot >=1.2.4
+        - dataclasses  # [py<37]
+        - flatten-dict >=0.3.0,<1
+        - tabulate >=0.8.7
+        - pygtrie ==2.3.2
+        - dpath >=1.4.2
+        - shtab >=1.3.2,<2
+        - rich >=3.0.5
+
+  - name: _dvc-gs
+    build:
+      noarch: generic
+    requirements:
+      run:
+        - {{ pin_subpackage("_dvc", exact=True) }}
+        - google-cloud-storage ==1.19.0
+
+  - name: _dvc-gdrive
+    build:
+      noarch: generic
+    requirements:
+      run:
+        - {{ pin_subpackage("_dvc", exact=True) }}
+        - pydrive2 >=1.6.2
+
+  - name: _dvc-s3
+    build:
+      noarch: generic
+    requirements:
+      run:
+        - {{ pin_subpackage("_dvc", exact=True) }}
+        - boto3 >=1.9.201
+
+  - name: _dvc-azure
+    build:
+      noarch: generic
+    requirements:
+      run:
+        - {{ pin_subpackage("_dvc", exact=True) }}
+        - azure-storage-blob >=12.0
+        - knack
+
+  - name: _dvc-oss
+    build:
+      noarch: generic
+    requirements:
+      run:
+        - {{ pin_subpackage("_dvc", exact=True) }}
+        - azure-storage-blob >=12.0
+        - oss2 >=2.11.0
+
+  - name: _dvc-ssh
+    build:
+      noarch: generic
+    requirements:
+      run:
+        - {{ pin_subpackage("_dvc", exact=True) }}
+        - paramiko >=2.7.0
+        # for paramiko, see https://github.com/iterative/dvc/issues/4589
+        - invoke >=1.3
+
+  - name: _dvc-hdfs
+    build:
+      noarch: generic
+    requirements:
+      run:
+        - {{ pin_subpackage("_dvc", exact=True) }}
+        - pyarrow >=0.17.1
 
 about:
   home: https://dvc.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ test:
     - dvc
   commands:
     - dvc version
+    - 'dvc version | grep "Supports: azure, gdrive, gs, hdfs, http, https, s3, ssh, oss"'
 
 # DVC includes requirements-only extras to enable support for different
 # remotes. Here we build a `dvc` conda package equivalent to the `dvc[all]` pip
@@ -73,6 +74,16 @@ outputs:
         - dvc = dvc.main:main
       script:
         - python -m pip install . --no-deps -vv
+
+    # Base package supports dvc, but only supports built-in remotes
+    test:
+      requires:
+        - git
+      imports:
+        - dvc
+      commands:
+        - dvc version
+        - 'dvc version | grep "Supports: http, https"'
 
     requirements:
       host:


### PR DESCRIPTION
_closes #160_
_adds @asford to maintainers to support metapackage layout_ 

Build a `dvc` conda package equivalent to the `dvc[all]` pip
package, with a `_dvc` base package containing dvc alone. This allows a
happy-path of:

  `conda install -c conda-forge dvc`

supporting dvc and all remotes and a power-user path of:

  `conda install -c conda-forge _dvc _dvc-s3`

for dvc and specific remotes.

See comments in meta.yml for details.

-----------------------

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
