### PR TITLE
Add pip check command and missing requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -215,6 +215,7 @@ outputs:
       requires:
         - git
         - pip
+        - importlib-metadata  # Undeclared upstream dependency
       imports:
         - dvc
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 # Of the build properties here and below:
 # number is propagated into the outputs below
 build:
-  number: 0
+  number: 1
   skip: true  # [py<=36 and win]
 
 outputs:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,15 +47,14 @@ outputs:
         - ply >=3.9
         - colorama >=0.3.9
         - configobj >=5.0.6
-        - gitpython >=2.1.8
+        - gitpython >3
         - dulwich >=0.20.21
         - pygit2 >=1.5.0
-        - gitdb2 >=2.0.6
         - setuptools >=34.0.0
         - nanotime >=0.5.2
         - pyasn1 >=0.4.1
         - voluptuous >=0.11.7
-        - jsonpath-ng >=1.4.3
+        - jsonpath-ng >=1.5.1
         - requests >=2.22.0
         - grandalf ==0.6
         - distro >=1.3.0
@@ -74,27 +73,26 @@ outputs:
         - networkx >=2.1
         - psutil >=5.8.0
         - pydot >=1.2.4
-        - dataclasses  # [py<37]
+        - dataclasses ==0.7  # [py<37]
         - flatten-dict >=0.3.0,<1
         - tabulate >=0.8.7
         - pygtrie ==2.3.2
-        - dpath >=1.4.2
-        - shtab >=1.3.2,<2
+        - dpath >=2.0.1,<3
+        - shtab >=1.3.4,<2
         - rich >=10.0.0
-        - dictdiffer>=0.8.1
+        - dictdiffer >=0.8.1
         - python-benedict >=0.21.1
         - pyparsing ==2.4.7
         - typing_extensions >=3.7.4
         - fsspec >=0.8.5
         - diskcache >=5.2.1
+        - importlib-metadata  # Undeclared upstream dependency
 
   - name: dvc-gs
     test:
       requires:
         - git
         - pip
-        - ujson  # Undeclared upstream dependency
-        - importlib-metadata  # Undeclared upstream dependency
       imports:
         - dvc
       commands:
@@ -108,14 +106,14 @@ outputs:
         - python
         - {{ pin_subpackage("dvc", exact=True) }}
         - gcsfs >=0.7.2
+        - ujson  # Undeclared upstream dependency
+        - importlib-metadata  # Undeclared upstream dependency
 
   - name: dvc-gdrive
     test:
       requires:
         - git
         - pip
-        - ujson  # Undeclared upstream dependency
-        - importlib-metadata  # Undeclared upstream dependency
       imports:
         - dvc
       commands:
@@ -129,6 +127,8 @@ outputs:
         - python
         - {{ pin_subpackage("dvc", exact=True) }}
         - pydrive2 >=1.8.1
+        - ujson  # Undeclared upstream dependency
+        - importlib-metadata  # Undeclared upstream dependency
 
   - name: dvc-s3
     test:
@@ -148,6 +148,7 @@ outputs:
         - python
         - {{ pin_subpackage("dvc", exact=True) }}
         - boto3 >=1.9.201
+        - importlib-metadata  # Undeclared upstream dependency
 
   - name: dvc-azure
     test:
@@ -169,6 +170,7 @@ outputs:
         - adlfs >=0.7.0
         - azure-identity >=1.4.0
         - knack
+        - importlib-metadata  # Undeclared upstream dependency
 
   - name: dvc-oss
     test:
@@ -188,7 +190,8 @@ outputs:
         - python
         - {{ pin_subpackage("dvc", exact=True) }}
         - oss2 >=2.11.0
-
+        - importlib-metadata  # Undeclared upstream dependency
+	
   - name: dvc-ssh
     test:
       requires:
@@ -209,13 +212,13 @@ outputs:
         - paramiko >=2.7.0
         # for paramiko, see https://github.com/iterative/dvc/issues/4589
         - invoke >=1.3
+        - importlib-metadata  # Undeclared upstream dependency
 
   - name: dvc-hdfs
     test:
       requires:
         - git
         - pip
-        - importlib-metadata  # Undeclared upstream dependency
       imports:
         - dvc
       commands:
@@ -229,6 +232,7 @@ outputs:
         - python
         - {{ pin_subpackage("dvc", exact=True) }}
         - pyarrow >=0.17.1
+        - importlib-metadata  # Undeclared upstream dependency
 
   - name: dvc-webhdfs
     test:
@@ -248,6 +252,7 @@ outputs:
         - python
         - {{ pin_subpackage("dvc", exact=True) }}
         - python-hdfs >=2.5.7
+        - importlib-metadata  # Undeclared upstream dependency
 
 about:
   home: https://dvc.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -93,6 +93,8 @@ outputs:
       requires:
         - git
         - pip
+        - ujson  # Undeclared upstream dependency
+        - importlib-metadata  # Undeclared upstream dependency
       imports:
         - dvc
       commands:
@@ -112,6 +114,8 @@ outputs:
       requires:
         - git
         - pip
+        - ujson  # Undeclared upstream dependency
+        - importlib-metadata  # Undeclared upstream dependency
       imports:
         - dvc
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,9 +30,11 @@ outputs:
     test:
       requires:
         - git
+        - pip
       imports:
         - dvc
       commands:
+        - pip check
         - dvc version
         - 'dvc version | grep "Supports: http, https"'
 
@@ -79,6 +81,8 @@ outputs:
         - dpath >=1.4.2
         - shtab >=1.3.2,<2
         - rich >=10.0.0
+        - dictdiffer>=0.8.1
+        - python-benedict >=0.21.1
         - pyparsing ==2.4.7
         - typing_extensions >=3.7.4
         - fsspec >=0.8.5
@@ -88,9 +92,11 @@ outputs:
     test:
       requires:
         - git
+        - pip
       imports:
         - dvc
       commands:
+        - pip check
         - dvc version
         - dvc version | grep gs
     requirements:
@@ -105,9 +111,11 @@ outputs:
     test:
       requires:
         - git
+        - pip
       imports:
         - dvc
       commands:
+        - pip check
         - dvc version
         - dvc version | grep gdrive
     requirements:
@@ -122,9 +130,11 @@ outputs:
     test:
       requires:
         - git
+        - pip
       imports:
         - dvc
       commands:
+        - pip check
         - dvc version
         - dvc version | grep s3
     requirements:
@@ -139,9 +149,11 @@ outputs:
     test:
       requires:
         - git
+        - pip
       imports:
         - dvc
       commands:
+        - pip check
         - dvc version
         - dvc version | grep azure
     requirements:
@@ -158,9 +170,11 @@ outputs:
     test:
       requires:
         - git
+        - pip
       imports:
         - dvc
       commands:
+        - pip check
         - dvc version
         - dvc version | grep oss
     requirements:
@@ -175,9 +189,11 @@ outputs:
     test:
       requires:
         - git
+        - pip
       imports:
         - dvc
       commands:
+        - pip check
         - dvc version
         - dvc version | grep ssh
     requirements:
@@ -194,9 +210,11 @@ outputs:
     test:
       requires:
         - git
+        - pip
       imports:
         - dvc
       commands:
+        - pip check
         - dvc version
         - dvc version | grep hdfs
     requirements:
@@ -211,9 +229,11 @@ outputs:
     test:
       requires:
         - git
+        - pip
       imports:
         - dvc
       commands:
+        - pip check
         - dvc version
         - dvc version | grep webhdfs
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,6 +73,7 @@ outputs:
         - networkx >=2.1
         - psutil >=5.8.0
         - pydot >=1.2.4
+        - speedcopy >=2.0.1  # [py<38 and win]
         - dataclasses ==0.7  # [py<37]
         - flatten-dict >=0.3.0,<1
         - tabulate >=0.8.7
@@ -191,7 +192,7 @@ outputs:
         - {{ pin_subpackage("dvc", exact=True) }}
         - oss2 >=2.11.0
         - importlib-metadata  # Undeclared upstream dependency
-	
+
   - name: dvc-ssh
     test:
       requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -107,7 +107,6 @@ outputs:
         - python
         - {{ pin_subpackage("dvc", exact=True) }}
         - gcsfs >=0.7.2
-        - ujson  # Undeclared upstream dependency
         - importlib-metadata  # Undeclared upstream dependency
 
   - name: dvc-gdrive
@@ -128,7 +127,6 @@ outputs:
         - python
         - {{ pin_subpackage("dvc", exact=True) }}
         - pydrive2 >=1.8.1
-        - ujson  # Undeclared upstream dependency
         - importlib-metadata  # Undeclared upstream dependency
 
   - name: dvc-s3


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [x] Ensured the license file is being packaged.

After installing `dvc` I was getting the following errors when running `pip check`:
```
dvc 2.0.17 requires dictdiffer, which is not installed.
dvc 2.0.17 requires python-benedict, which is not installed.
```